### PR TITLE
전자정부 표준프레임워크 표준 Inspection 룰셋으로 시큐어코딩 PMD 진단/조치 재요청

### DIFF
--- a/src/main/java/egovframework/example/exception/EgovAopExceptionTransfer.java
+++ b/src/main/java/egovframework/example/exception/EgovAopExceptionTransfer.java
@@ -16,9 +16,11 @@ public class EgovAopExceptionTransfer {
 	}
 
 	@Pointcut("execution(* egovframework.example..impl.*Impl.*(..))")
-	private void exceptionTransferService() {}
+	public void exceptionTransferService() {
+		// 포인트컷 빈메소드임
+	}
 
-	@AfterThrowing(pointcut="exceptionTransferService()", throwing="ex")
+	@AfterThrowing(pointcut = "exceptionTransferService()", throwing = "ex")
 	public void doAfterThrowingExceptionTransferService(JoinPoint thisJoinPoint, Exception ex) throws Exception {
 		exceptionTransfer.transfer(thisJoinPoint, ex);
 	}


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

```
해당 메서드는 Pointcut 표현식을 정의하기 위해 사용된 메서드로 Spring AOP에 의해 정의된 Pointcut에 해당하는 메서드 호출을 가로채기 위해 사용됩니다.

이 메서드는 실제로 코드가 실행될 때 호출되지 않기 때문에 @Pointcut 메서드에 코드를 추가하면 @Pointcut 메서드가 실제로 실행되는 것처럼 보이므로 오히려 혼란을 줄 수 있습니다.

공식 문서를 참조하여 보시기 바랍니다.
https://docs.spring.io/spring-framework/reference/core/aop/ataspectj/pointcuts.html
```

공식 문서 확인했습니다. 개발가이드 감사합니다! 포인트컷 선언 배우네요~

public 메서드로 수정하고 빈 메소드에 빈메소드임을 나타내는 주석을 추가하면
`@Pointcut` 메서드가 실제로 실행되는 것처럼 보이는 혼란을 주지 않고, 포인트컷 빈메소드임을 나타낼 수 있을 것 같습니다.

```java 
	@Pointcut("execution(* egovframework.example..impl.*Impl.*(..))")
	public void exceptionTransferService() {
		// 포인트컷 빈메소드임
	}
```

public 메서드에 포인트컷 선언 예

포인트컷 표현식 결합(Combining Pointcut Expressions)
- https://docs.spring.io/spring-framework/reference/core/aop/ataspectj/pointcuts.html#aop-pointcuts-combining

명명된 Pointcut 정의 공유(Sharing Named Pointcut Definitions)
- https://docs.spring.io/spring-framework/reference/core/aop/ataspectj/pointcuts.html#aop-common-pointcuts


## 전자정부 표준프레임워크 표준 Inspection 룰셋으로 시큐어코딩 PMD 진단/조치 재요청

전자정부 표준프레임워크 표준 Inspection 룰셋 적용하기
- https://www.egovframe.go.kr/wiki/doku.php?id=egovframework:dev4.2:imp:inspection#%EC%A0%84%EC%9E%90%EC%A0%95%EB%B6%80_%ED%91%9C%EC%A4%80%ED%94%84%EB%A0%88%EC%9E%84%EC%9B%8C%ED%81%AC_%ED%91%9C%EC%A4%80_inspection_%EB%A3%B0%EC%85%8B_%EC%A0%81%EC%9A%A9%ED%95%98%EA%B8%B0
- 표준 Inspection 룰셋 한글/영문판의 압축파일 : 개발환경 4.2 이상 버전 사용
- egovinspectionrules-4.2.zip

### EgovAopExceptionTransfer

전자정부 표준프레임워크 표준 Inspection 룰셋
번호|PMD 룰|설명|SW 보안 약점
-|-|-|-
35|UncommentedEmptyMethodBody|빈 메소드에 빈메소드임을 나타내는 주석을 추가할 것|
42|UnusedPrivateMethod|사용되지 않는 Private Method 선언을 탐지|

http://localhost:8080/

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/xn79jsgTVS8
