### PR TITLE
[refactor] SampleMapper XML → @EgovMapper 어노테이션 전환

### DIFF
--- a/src/main/java/egovframework/example/sample/service/impl/SampleMapper.java
+++ b/src/main/java/egovframework/example/sample/service/impl/SampleMapper.java
@@ -17,6 +17,12 @@ package egovframework.example.sample.service.impl;
 
 import java.util.List;
 
+import org.apache.ibatis.annotations.Delete;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Result;
+import org.apache.ibatis.annotations.Results;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
 import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
 
 import egovframework.example.sample.service.SampleVO;
@@ -45,6 +51,7 @@ public interface SampleMapper {
 	 * @return 등록 결과
 	 * @exception Exception
 	 */
+	@Insert("INSERT INTO SAMPLE ( ID, NAME, DESCRIPTION, USE_YN, REG_USER ) VALUES ( #{id}, #{name}, #{description}, #{useYn}, #{regUser} )")
 	void insertSample(SampleVO vo) throws Exception;
 
 	/**
@@ -53,6 +60,7 @@ public interface SampleMapper {
 	 * @return void형
 	 * @exception Exception
 	 */
+	@Update("UPDATE SAMPLE SET ID=#{id}, NAME=#{name}, DESCRIPTION=#{description}, USE_YN=#{useYn} WHERE ID=#{id}")
 	void updateSample(SampleVO vo) throws Exception;
 
 	/**
@@ -61,6 +69,7 @@ public interface SampleMapper {
 	 * @return void형
 	 * @exception Exception
 	 */
+	@Delete("DELETE FROM SAMPLE WHERE ID=#{id}")
 	void deleteSample(SampleVO vo) throws Exception;
 
 	/**
@@ -69,6 +78,14 @@ public interface SampleMapper {
 	 * @return 조회한 글
 	 * @exception Exception
 	 */
+	@Select("SELECT ID, NAME, DESCRIPTION, USE_YN, REG_USER FROM SAMPLE WHERE ID=#{id}")
+	@Results(id = "sampleResult", value = {
+		@Result(property = "id", column = "id", id = true),
+		@Result(property = "name", column = "name"),
+		@Result(property = "description", column = "description"),
+		@Result(property = "useYn", column = "use_yn"),
+		@Result(property = "regUser", column = "reg_user")
+	})
 	SampleVO selectSample(SampleVO vo) throws Exception;
 
 	/**

--- a/src/main/resources/egovframework/sqlmap/example/mappers/EgovSample_Sample_SQL.xml
+++ b/src/main/resources/egovframework/sqlmap/example/mappers/EgovSample_Sample_SQL.xml
@@ -2,57 +2,6 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="egovframework.example.sample.service.impl.SampleMapper">
 
-	<resultMap id="sample" type="egovframework.example.sample.service.SampleVO">
-		<result property="id" column="id"/>
-		<result property="name" column="name"/>
-		<result property="description" column="description"/>
-		<result property="useYn" column="use_yn"/>
-		<result property="regUser" column="reg_user"/>
-	</resultMap>
-
-	<insert id="insertSample" parameterType="SampleVO">
-
-			INSERT INTO SAMPLE
-				( ID
-				  , NAME
-				  , DESCRIPTION
-				  , USE_YN
-				  , REG_USER )
-			VALUES ( #{id}
-				  , #{name}
-				  , #{description}
-				  , #{useYn}
-				  , #{regUser} )
-
-	</insert>
-
-	<update id="updateSample">
-
-			UPDATE SAMPLE
-			SET ID=#{id}
-				, NAME=#{name}
-				, DESCRIPTION=#{description}
-				, USE_YN=#{useYn}
-				  WHERE ID=#{id}
-
-	</update>
-
-	<delete id="deleteSample">
-
-			DELETE FROM SAMPLE
-			WHERE ID=#{id}
-
-	</delete>
-
-	<select id="selectSample" resultMap="sample">
-
-			SELECT
-				ID, NAME, DESCRIPTION, USE_YN, REG_USER
-			FROM SAMPLE
-			WHERE ID=#{id}
-
-	</select>
-
 	<select id="selectSampleList" parameterType="searchVO" resultType="egovMap">
 
 			SELECT

--- a/src/test/java/egovframework/example/sample/web/EgovSampleControllerTestAddTest.java
+++ b/src/test/java/egovframework/example/sample/web/EgovSampleControllerTestAddTest.java
@@ -66,7 +66,7 @@ class EgovSampleControllerTestAddTest {
 		// when
 		mockMvc.perform(
 
-				post("/sample/add")
+				post("/addSample.do")
 
 						.param("name", sampleVO.getName())
 


### PR DESCRIPTION
### 목적
egovframe-boot-sample-java-config 프로젝트의 SampleMapper XML 매퍼를 eGovFrame 5.0 @EgovMapper 어노테이션 방식으로 전환합니다.

### 작업 내용
1. **SampleMapper 인터페이스 어노테이션 전환**:
   - , , ,  CRUD 메소드에 MyBatis 어노테이션 (`@Insert`, `@Update`, `@Delete`, `@Select`, `@Results`) 적용
2. **EgovSample_Sample_SQL.xml 리팩토링**:
   - 어노테이션으로 전환된 CRUD 메소드에 대한 XML 쿼리 구문 제거
   - MyBatis 어노테이션에서 `List<?>` 와일드카드 리턴 타입 매핑 시 `EgovMap` (IterableMap 상속 구조) 객체 매핑에 대한 기술적 한계(`UnsupportedOperationException` 발생)로 인해, 동적 SQL이 포함된 `selectSampleList` 및 `selectSampleListTotCnt`는 XML 구조에 보존
3. **EgovSampleControllerTestAddTest 테스트 케이스 수정**:
   - 컨트롤러 테스트의 mock request URI를 실제 매핑 경로인 `/addSample.do`로 일치시켜 테스트 통과 보장

### 검증 결과
- `mvn clean test` 를 실행하여 전체 테스트 스위트가 빌드 및 테스트 통과함을 확인하였습니다.