### PR TITLE
[test][boot-sample] EgovSampleController update/delete/selectList 단위 테스트 추가

### DIFF
--- a/src/test/java/egovframework/example/sample/web/EgovSampleControllerTestDeleteTest.java
+++ b/src/test/java/egovframework/example/sample/web/EgovSampleControllerTestDeleteTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2008-2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package egovframework.example.sample.web;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import egovframework.example.sample.service.EgovSampleService;
+import egovframework.example.sample.service.SampleVO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * [게시판][EgovSampleController.delete] Controller 단위 테스트
+ *
+ * @author 표준프레임워크센터
+ * @since 2025.01.01
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@RequiredArgsConstructor
+@Slf4j
+class EgovSampleControllerTestDeleteTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private EgovSampleService egovSampleService;
+
+	@Test
+	void test() throws Exception {
+		// given - 등록
+		final SampleVO insertVO = new SampleVO();
+		final String now = LocalDateTime.now().toString();
+		insertVO.setName("test 삭제대상 카테고리명 " + now);
+		insertVO.setDescription("test 삭제대상 설명 " + now);
+		insertVO.setUseYn("Y");
+		insertVO.setRegUser("eGov");
+		egovSampleService.insertSample(insertVO);
+
+		insertVO.setRecordCountPerPage(10);
+		insertVO.setFirstIndex(0);
+		insertVO.setSearchCondition("1");
+		insertVO.setSearchKeyword(insertVO.getName());
+		final List<?> insertedList = egovSampleService.selectSampleList(insertVO);
+		final EgovMap insertedRow = (EgovMap) insertedList.get(0);
+		final String insertedId = (String) insertedRow.get("id");
+
+		// when
+		mockMvc.perform(
+				post("/deleteSample.do")
+						.param("id", insertedId)
+		)
+				.andDo(print())
+				.andExpect(status().is3xxRedirection())
+				.andExpect(redirectedUrlPattern("/egovSampleList.do*"));
+
+		// then - 삭제 후 조회 시 예외 발생
+		if (log.isDebugEnabled()) {
+			log.debug("insertedId={}", insertedId);
+		}
+
+		final SampleVO queryVO = new SampleVO();
+		queryVO.setId(insertedId);
+		assertThrows(Exception.class, () -> egovSampleService.selectSample(queryVO), "글을 삭제한다. 삭제 후 조회 불가");
+	}
+
+}

--- a/src/test/java/egovframework/example/sample/web/EgovSampleControllerTestSelectListTest.java
+++ b/src/test/java/egovframework/example/sample/web/EgovSampleControllerTestSelectListTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2008-2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package egovframework.example.sample.web;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * [게시판][EgovSampleController.selectList] Controller 단위 테스트
+ *
+ * @author 표준프레임워크센터
+ * @since 2025.01.01
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@RequiredArgsConstructor
+@Slf4j
+class EgovSampleControllerTestSelectListTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	void test_목록조회_기본() throws Exception {
+		mockMvc.perform(get("/egovSampleList.do"))
+				.andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(view().name("sample/egovSampleList"))
+				.andExpect(model().attributeExists("resultList"))
+				.andExpect(model().attributeExists("paginationInfo"));
+	}
+
+	@Test
+	void test_목록조회_검색조건_이름() throws Exception {
+		mockMvc.perform(
+				get("/egovSampleList.do")
+						.param("searchCondition", "1")
+						.param("searchKeyword", "테스트")
+						.param("pageIndex", "1")
+		)
+				.andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(view().name("sample/egovSampleList"))
+				.andExpect(model().attributeExists("resultList"))
+				.andExpect(model().attributeExists("paginationInfo"));
+	}
+
+	@Test
+	void test_인덱스_리다이렉트() throws Exception {
+		mockMvc.perform(get("/"))
+				.andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(view().name("sample/egovSampleList"));
+	}
+
+}

--- a/src/test/java/egovframework/example/sample/web/EgovSampleControllerTestUpdateTest.java
+++ b/src/test/java/egovframework/example/sample/web/EgovSampleControllerTestUpdateTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2008-2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package egovframework.example.sample.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import egovframework.example.sample.service.EgovSampleService;
+import egovframework.example.sample.service.SampleVO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * [게시판][EgovSampleController.update] Controller 단위 테스트
+ *
+ * @author 표준프레임워크센터
+ * @since 2025.01.01
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@RequiredArgsConstructor
+@Slf4j
+class EgovSampleControllerTestUpdateTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private EgovSampleService egovSampleService;
+
+	@Test
+	void test() throws Exception {
+		// given - 등록
+		final SampleVO insertVO = new SampleVO();
+		final String now = LocalDateTime.now().toString();
+		insertVO.setName("test 수정전 카테고리명 " + now);
+		insertVO.setDescription("test 수정전 설명 " + now);
+		insertVO.setUseYn("Y");
+		insertVO.setRegUser("eGov");
+		egovSampleService.insertSample(insertVO);
+
+		insertVO.setRecordCountPerPage(10);
+		insertVO.setFirstIndex(0);
+		insertVO.setSearchCondition("1");
+		insertVO.setSearchKeyword(insertVO.getName());
+		final List<?> insertedList = egovSampleService.selectSampleList(insertVO);
+		final EgovMap insertedRow = (EgovMap) insertedList.get(0);
+		final String insertedId = (String) insertedRow.get("id");
+
+		final String updatedName = "test 수정후 카테고리명 " + now;
+		final String updatedDescription = "test 수정후 설명 " + now;
+
+		// when
+		mockMvc.perform(
+				post("/updateSample.do")
+						.param("id", insertedId)
+						.param("name", updatedName)
+						.param("description", updatedDescription)
+						.param("useYn", "N")
+						.param("regUser", "eGov")
+		)
+				.andDo(print())
+				.andExpect(status().is3xxRedirection())
+				.andExpect(redirectedUrlPattern("/egovSampleList.do*"));
+
+		// then
+		final SampleVO queryVO = new SampleVO();
+		queryVO.setId(insertedId);
+		final SampleVO result = egovSampleService.selectSample(queryVO);
+
+		if (log.isDebugEnabled()) {
+			log.debug("insertedId={}", insertedId);
+			log.debug("updatedName={}, result.getName={}", updatedName, result.getName());
+			log.debug("updatedDescription={}, result.getDescription={}", updatedDescription, result.getDescription());
+		}
+
+		assertEquals(updatedName, result.getName(), "글을 수정한다. 카테고리명");
+		assertEquals(updatedDescription, result.getDescription(), "글을 수정한다. 설명");
+		assertEquals("N", result.getUseYn(), "글을 수정한다. 사용여부");
+	}
+
+}


### PR DESCRIPTION
## 변경 사유

EgovSampleController의 수정(update), 삭제(delete), 목록 조회(selectList) 흐름에 대한 테스트가 없어 추가한다.

## 변경 내용

- `EgovSampleControllerTestUpdateTest`: POST /updateSample.do 호출 후 name, description, useYn 변경 검증
- `EgovSampleControllerTestDeleteTest`: POST /deleteSample.do 호출 후 selectSample 조회 시 예외 발생 검증
- `EgovSampleControllerTestSelectListTest`: GET /egovSampleList.do 기본 조회, 검색 조건 적용, 루트 경로(/) 응답 검증

MockMvc + @SpringBootTest + @AutoConfigureMockMvc 방식으로 Controller 레이어를 통합 테스트한다.

## 테스트 결과

```
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
```

## 체크리스트

- [x] 단일 주제만 다룸 (Controller 테스트 추가)
- [x] 기존 동작에 영향 없음 (테스트 코드만 추가)
- [x] 테스트 통과 확인
