### PR TITLE
[test][boot-sample] SampleVO 및 SampleDefaultVO 단위 테스트 추가

### DIFF
--- a/src/test/java/egovframework/example/sample/service/SampleDefaultVOTest.java
+++ b/src/test/java/egovframework/example/sample/service/SampleDefaultVOTest.java
@@ -1,0 +1,79 @@
+package egovframework.example.sample.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * SampleDefaultVO 단위 테스트
+ *
+ * 검색 조건, 페이지 정보 등 기본 VO 필드의 기본값과
+ * setter/getter 동작을 검증한다.
+ */
+class SampleDefaultVOTest {
+
+	private SampleDefaultVO vo;
+
+	@BeforeEach
+	void setUp() {
+		vo = new SampleDefaultVO();
+	}
+
+	@Test
+	@DisplayName("기본값 확인 - 검색조건 및 키워드는 빈 문자열")
+	void defaultValues_searchFields() {
+		assertThat(vo.getSearchCondition()).isEmpty();
+		assertThat(vo.getSearchKeyword()).isEmpty();
+		assertThat(vo.getSearchUseYn()).isEmpty();
+	}
+
+	@Test
+	@DisplayName("기본값 확인 - 페이지 관련 필드는 1 또는 10")
+	void defaultValues_pageFields() {
+		assertThat(vo.getPageIndex()).isEqualTo(1);
+		assertThat(vo.getPageUnit()).isEqualTo(10);
+		assertThat(vo.getPageSize()).isEqualTo(10);
+		assertThat(vo.getFirstIndex()).isEqualTo(1);
+		assertThat(vo.getLastIndex()).isEqualTo(1);
+		assertThat(vo.getRecordCountPerPage()).isEqualTo(10);
+	}
+
+	@Test
+	@DisplayName("검색조건 setter/getter 정상 동작")
+	void setterGetter_searchCondition() {
+		vo.setSearchCondition("SEARCH_NM");
+		vo.setSearchKeyword("테스트");
+		vo.setSearchUseYn("Y");
+
+		assertThat(vo.getSearchCondition()).isEqualTo("SEARCH_NM");
+		assertThat(vo.getSearchKeyword()).isEqualTo("테스트");
+		assertThat(vo.getSearchUseYn()).isEqualTo("Y");
+	}
+
+	@Test
+	@DisplayName("페이지 관련 setter/getter 정상 동작")
+	void setterGetter_pageFields() {
+		vo.setPageIndex(3);
+		vo.setPageUnit(20);
+		vo.setPageSize(5);
+		vo.setFirstIndex(41);
+		vo.setLastIndex(60);
+		vo.setRecordCountPerPage(20);
+
+		assertThat(vo.getPageIndex()).isEqualTo(3);
+		assertThat(vo.getPageUnit()).isEqualTo(20);
+		assertThat(vo.getPageSize()).isEqualTo(5);
+		assertThat(vo.getFirstIndex()).isEqualTo(41);
+		assertThat(vo.getLastIndex()).isEqualTo(60);
+		assertThat(vo.getRecordCountPerPage()).isEqualTo(20);
+	}
+
+	@Test
+	@DisplayName("toString 은 null 을 반환하지 않는다")
+	void toString_notNull() {
+		assertThat(vo.toString()).isNotNull();
+	}
+
+}

--- a/src/test/java/egovframework/example/sample/service/SampleVOTest.java
+++ b/src/test/java/egovframework/example/sample/service/SampleVOTest.java
@@ -1,0 +1,88 @@
+package egovframework.example.sample.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * SampleVO 단위 테스트
+ *
+ * 게시글 VO 필드의 setter/getter 동작과
+ * 부모 클래스(SampleDefaultVO) 상속 관계를 검증한다.
+ */
+class SampleVOTest {
+
+	private SampleVO vo;
+
+	@BeforeEach
+	void setUp() {
+		vo = new SampleVO();
+	}
+
+	@Test
+	@DisplayName("새로 생성된 SampleVO 의 필드는 null 이다")
+	void newInstance_fieldsAreNull() {
+		assertThat(vo.getId()).isNull();
+		assertThat(vo.getName()).isNull();
+		assertThat(vo.getDescription()).isNull();
+		assertThat(vo.getUseYn()).isNull();
+		assertThat(vo.getRegUser()).isNull();
+	}
+
+	@Test
+	@DisplayName("id setter/getter 정상 동작")
+	void setterGetter_id() {
+		vo.setId("SAMPLE-001");
+		assertThat(vo.getId()).isEqualTo("SAMPLE-001");
+	}
+
+	@Test
+	@DisplayName("name setter/getter 정상 동작")
+	void setterGetter_name() {
+		vo.setName("테스트 카테고리");
+		assertThat(vo.getName()).isEqualTo("테스트 카테고리");
+	}
+
+	@Test
+	@DisplayName("description setter/getter 정상 동작")
+	void setterGetter_description() {
+		vo.setDescription("테스트 설명입니다.");
+		assertThat(vo.getDescription()).isEqualTo("테스트 설명입니다.");
+	}
+
+	@Test
+	@DisplayName("useYn setter/getter 정상 동작")
+	void setterGetter_useYn() {
+		vo.setUseYn("Y");
+		assertThat(vo.getUseYn()).isEqualTo("Y");
+
+		vo.setUseYn("N");
+		assertThat(vo.getUseYn()).isEqualTo("N");
+	}
+
+	@Test
+	@DisplayName("regUser setter/getter 정상 동작")
+	void setterGetter_regUser() {
+		vo.setRegUser("eGov");
+		assertThat(vo.getRegUser()).isEqualTo("eGov");
+	}
+
+	@Test
+	@DisplayName("SampleVO 는 SampleDefaultVO 를 상속한다")
+	void inheritsSampleDefaultVO() {
+		assertThat(vo).isInstanceOf(SampleDefaultVO.class);
+	}
+
+	@Test
+	@DisplayName("부모 페이지 필드도 정상 동작한다")
+	void parentPageFields_accessible() {
+		vo.setPageIndex(2);
+		vo.setPageUnit(5);
+
+		assertThat(vo.getPageIndex()).isEqualTo(2);
+		assertThat(vo.getPageUnit()).isEqualTo(5);
+	}
+
+}


### PR DESCRIPTION
Spring 컨텍스트 없이 실행 가능한 VO 순수 단위 테스트를 추가합니다.

## 변경 내용

- `SampleDefaultVOTest`: 검색 조건 필드 기본값, 페이지 관련 필드 기본값, setter/getter, toString 검증 (5건)
- `SampleVOTest`: 필드별 null 초기 상태, setter/getter, SampleDefaultVO 상속 관계, 부모 페이지 필드 접근 검증 (8건)

## 테스트 환경

- JUnit 5, AssertJ
- Spring 컨텍스트 불필요 — 순수 POJO 단위 테스트
- `mvn test -Dtest="SampleDefaultVOTest,SampleVOTest"` → 13/13 통과

## 체크리스트

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 기존 동작에 영향 없음
- [x] 테스트 통과 확인 (BUILD SUCCESS)
