### PR TITLE
[test][boot-sample] 예외 핸들러 단위 테스트 추가

### DIFF
--- a/src/test/java/egovframework/example/exception/EgovAopExceptionTransferTest.java
+++ b/src/test/java/egovframework/example/exception/EgovAopExceptionTransferTest.java
@@ -1,0 +1,57 @@
+package egovframework.example.exception;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.aspectj.lang.JoinPoint;
+import org.egovframe.rte.fdl.cmmn.aspect.ExceptionTransfer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * EgovAopExceptionTransfer 단위 테스트
+ *
+ * @author 이백행
+ * @since 2025-05-28
+ */
+class EgovAopExceptionTransferTest {
+
+	private EgovAopExceptionTransfer exceptionTransfer;
+	private ExceptionTransfer mockExceptionTransfer;
+
+	@BeforeEach
+	void setUp() {
+		exceptionTransfer = new EgovAopExceptionTransfer();
+		mockExceptionTransfer = mock(ExceptionTransfer.class);
+		exceptionTransfer.setExceptionTransfer(mockExceptionTransfer);
+	}
+
+	@Test
+	@DisplayName("doAfterThrowingExceptionTransferService - ExceptionTransfer.transfer 위임 확인")
+	void testDoAfterThrowingDelegatesToExceptionTransfer() throws Exception {
+		JoinPoint joinPoint = mock(JoinPoint.class);
+		Exception ex = new RuntimeException("서비스 예외");
+
+		exceptionTransfer.doAfterThrowingExceptionTransferService(joinPoint, ex);
+
+		verify(mockExceptionTransfer).transfer(eq(joinPoint), eq(ex));
+	}
+
+	@Test
+	@DisplayName("setExceptionTransfer - 의존성 주입 후 transfer 호출 가능")
+	void testSetExceptionTransfer() throws Exception {
+		ExceptionTransfer another = mock(ExceptionTransfer.class);
+		exceptionTransfer.setExceptionTransfer(another);
+
+		JoinPoint joinPoint = mock(JoinPoint.class);
+		Exception ex = new IllegalStateException("상태 예외");
+
+		exceptionTransfer.doAfterThrowingExceptionTransferService(joinPoint, ex);
+
+		verify(another).transfer(any(JoinPoint.class), eq(ex));
+	}
+
+}

--- a/src/test/java/egovframework/example/exception/EgovSampleExcepHndlrTest.java
+++ b/src/test/java/egovframework/example/exception/EgovSampleExcepHndlrTest.java
@@ -1,0 +1,45 @@
+package egovframework.example.exception;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * EgovSampleExcepHndlr 단위 테스트
+ *
+ * @author 이백행
+ * @since 2025-05-28
+ */
+class EgovSampleExcepHndlrTest {
+
+	private EgovSampleExcepHndlr handler;
+
+	@BeforeEach
+	void setUp() {
+		handler = new EgovSampleExcepHndlr();
+	}
+
+	@Test
+	@DisplayName("occur 메서드 - RuntimeException 발생 시 예외 없이 처리")
+	void testOccurWithRuntimeException() {
+		RuntimeException ex = new RuntimeException("테스트 예외");
+		assertDoesNotThrow(() -> handler.occur(ex, "egovframework.example"));
+	}
+
+	@Test
+	@DisplayName("occur 메서드 - 일반 Exception 발생 시 예외 없이 처리")
+	void testOccurWithException() {
+		Exception ex = new Exception("일반 예외");
+		assertDoesNotThrow(() -> handler.occur(ex, "egovframework.example.sample"));
+	}
+
+	@Test
+	@DisplayName("occur 메서드 - 빈 패키지명으로 호출 시 예외 없이 처리")
+	void testOccurWithEmptyPackageName() {
+		Exception ex = new IllegalArgumentException("잘못된 인수");
+		assertDoesNotThrow(() -> handler.occur(ex, ""));
+	}
+
+}

--- a/src/test/java/egovframework/example/exception/EgovSampleOthersExcepHndlrTest.java
+++ b/src/test/java/egovframework/example/exception/EgovSampleOthersExcepHndlrTest.java
@@ -1,0 +1,45 @@
+package egovframework.example.exception;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * EgovSampleOthersExcepHndlr 단위 테스트
+ *
+ * @author 이백행
+ * @since 2025-05-28
+ */
+class EgovSampleOthersExcepHndlrTest {
+
+	private EgovSampleOthersExcepHndlr handler;
+
+	@BeforeEach
+	void setUp() {
+		handler = new EgovSampleOthersExcepHndlr();
+	}
+
+	@Test
+	@DisplayName("occur 메서드 - RuntimeException 발생 시 예외 없이 처리")
+	void testOccurWithRuntimeException() {
+		RuntimeException ex = new RuntimeException("런타임 예외");
+		assertDoesNotThrow(() -> handler.occur(ex, "egovframework.example"));
+	}
+
+	@Test
+	@DisplayName("occur 메서드 - 일반 Exception 발생 시 예외 없이 처리")
+	void testOccurWithException() {
+		Exception ex = new Exception("일반 예외");
+		assertDoesNotThrow(() -> handler.occur(ex, "egovframework.example.sample"));
+	}
+
+	@Test
+	@DisplayName("occur 메서드 - NullPointerException 발생 시 예외 없이 처리")
+	void testOccurWithNullPointerException() {
+		NullPointerException ex = new NullPointerException("널 포인터 예외");
+		assertDoesNotThrow(() -> handler.occur(ex, "egovframework.example.service"));
+	}
+
+}


### PR DESCRIPTION
예외 처리 클래스 3종에 대한 JUnit 5 단위 테스트를 추가한다.

**변경 파일**
- `EgovSampleExcepHndlrTest` — `occur()` 메서드가 RuntimeException / Exception / IllegalArgumentException 입력에서 예외를 전파하지 않음을 검증 (3건)
- `EgovSampleOthersExcepHndlrTest` — 동일 패턴으로 others 핸들러 검증 (3건)
- `EgovAopExceptionTransferTest` — Mockito를 활용해 `ExceptionTransfer.transfer()` 위임 호출 여부 검증 (2건)

**테스트 결과**
```
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0 — BUILD SUCCESS
```

- [ ] 단일 주제만 다룸 (예외 핸들러 테스트만 포함)
- [ ] 기존 동작에 영향 없음 (테스트 코드 추가만)
- [ ] 테스트 통과 확인 (8건 전원 통과)
