### PR TITLE
[test][boot-sample] EgovPaginationDialect 단위 테스트 추가

### DIFF
--- a/src/test/java/egovframework/example/pagination/EgovPaginationDialectTest.java
+++ b/src/test/java/egovframework/example/pagination/EgovPaginationDialectTest.java
@@ -1,0 +1,68 @@
+package egovframework.example.pagination;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.thymeleaf.expression.IExpressionObjectFactory;
+
+/**
+ * EgovPaginationDialect 단위 테스트
+ *
+ * @author 이백행
+ * @since 2026-05-28
+ */
+class EgovPaginationDialectTest {
+
+	private EgovKrdsPaginationRenderer renderer;
+	private EgovPaginationDialect dialect;
+
+	@BeforeEach
+	void setUp() {
+		renderer = mock(EgovKrdsPaginationRenderer.class);
+		dialect = new EgovPaginationDialect(renderer);
+	}
+
+	@Test
+	@DisplayName("Dialect 이름이 EgovPaginationDialect로 등록된다")
+	void testDialectName() {
+		assertEquals("EgovPaginationDialect", dialect.getName());
+	}
+
+	@Test
+	@DisplayName("ExpressionObjectFactory가 null이 아니다")
+	void testGetExpressionObjectFactoryNotNull() {
+		IExpressionObjectFactory factory = dialect.getExpressionObjectFactory();
+		assertNotNull(factory);
+	}
+
+	@Test
+	@DisplayName("ExpressionObject 이름 목록에 egovKrdsPaginationRenderer가 포함된다")
+	void testExpressionObjectNames() {
+		IExpressionObjectFactory factory = dialect.getExpressionObjectFactory();
+		Set<String> names = factory.getAllExpressionObjectNames();
+		assertTrue(names.contains("egovKrdsPaginationRenderer"));
+	}
+
+	@Test
+	@DisplayName("buildObject는 주입된 renderer 인스턴스를 반환한다")
+	void testBuildObjectReturnsRenderer() {
+		IExpressionObjectFactory factory = dialect.getExpressionObjectFactory();
+		Object result = factory.buildObject(null, "egovKrdsPaginationRenderer");
+		assertEquals(renderer, result);
+	}
+
+	@Test
+	@DisplayName("isCacheable은 egovKrdsPaginationRenderer에 대해 true를 반환한다")
+	void testIsCacheable() {
+		IExpressionObjectFactory factory = dialect.getExpressionObjectFactory();
+		assertTrue(factory.isCacheable("egovKrdsPaginationRenderer"));
+	}
+
+}


### PR DESCRIPTION
EgovPaginationDialect의 Thymeleaf 표현 객체 팩토리 동작을 검증하는 단위 테스트를 추가한다.

**변경 파일**
- `src/test/java/egovframework/example/pagination/EgovPaginationDialectTest.java` (신규)

**테스트 케이스 (5건)**
1. Dialect 이름이 `EgovPaginationDialect`로 등록되는지 확인
2. `getExpressionObjectFactory()` 반환값이 null이 아닌지 확인
3. 표현 객체 이름 목록에 `egovKrdsPaginationRenderer`가 포함되는지 확인
4. `buildObject()`가 주입된 renderer 인스턴스를 그대로 반환하는지 확인
5. `isCacheable()`이 `egovKrdsPaginationRenderer`에 대해 true를 반환하는지 확인

**테스트 환경**: JUnit 5 + Mockito (EgovKrdsPaginationRenderer mock), Spring 컨텍스트 불필요한 순수 단위 테스트

**빌드 결과**: `mvn test -Dtest=EgovPaginationDialectTest` → Tests run: 5, Failures: 0, Errors: 0

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 기존 동작에 영향 없음
- [x] 테스트 통과 확인
