### PR TITLE
[test][boot-sample] EgovKrdsPaginationRenderer 단위 테스트 추가

### DIFF
--- a/src/test/java/egovframework/example/pagination/EgovKrdsPaginationRendererTest.java
+++ b/src/test/java/egovframework/example/pagination/EgovKrdsPaginationRendererTest.java
@@ -1,0 +1,127 @@
+package egovframework.example.pagination;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Locale;
+
+import org.egovframe.rte.ptl.mvc.tags.ui.pagination.PaginationInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.MessageSource;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * EgovKrdsPaginationRenderer 단위 테스트
+ *
+ * @author 이백행
+ * @since 2026-05-28
+ */
+class EgovKrdsPaginationRendererTest {
+
+	private EgovKrdsPaginationRenderer renderer;
+	private MessageSource messageSource;
+
+	@BeforeEach
+	void setUp() {
+		messageSource = mock(MessageSource.class);
+		when(messageSource.getMessage(eq("page.prev"), isNull(), eq("이전"), any(Locale.class))).thenReturn("이전");
+		when(messageSource.getMessage(eq("page.next"), isNull(), eq("다음"), any(Locale.class))).thenReturn("다음");
+
+		renderer = new EgovKrdsPaginationRenderer();
+		ReflectionTestUtils.setField(renderer, "messageSource", messageSource);
+		renderer.initMessageLabels();
+	}
+
+	@Test
+	@DisplayName("initVariables 호출 후 previousPageLabel이 null이 아니다")
+	void testInitVariablesPreviousPageLabel() {
+		renderer.initVariables();
+		String label = (String) ReflectionTestUtils.getField(renderer, "previousPageLabel");
+		assertThat(label).isNotNull().contains("page-navi prev");
+	}
+
+	@Test
+	@DisplayName("initVariables 호출 후 nextPageLabel이 null이 아니다")
+	void testInitVariablesNextPageLabel() {
+		renderer.initVariables();
+		String label = (String) ReflectionTestUtils.getField(renderer, "nextPageLabel");
+		assertThat(label).isNotNull().contains("page-navi next");
+	}
+
+	@Test
+	@DisplayName("initVariables 호출 후 currentPageLabel이 active 클래스를 포함한다")
+	void testInitVariablesCurrentPageLabel() {
+		renderer.initVariables();
+		String label = (String) ReflectionTestUtils.getField(renderer, "currentPageLabel");
+		assertThat(label).isNotNull().contains("active");
+	}
+
+	@Test
+	@DisplayName("initVariables 호출 후 dotPageLabel이 ... 을 포함한다")
+	void testInitVariablesDotPageLabel() {
+		renderer.initVariables();
+		String label = (String) ReflectionTestUtils.getField(renderer, "dotPageLabel");
+		assertThat(label).isNotNull().contains("...");
+	}
+
+	@Test
+	@DisplayName("initMessageLabels 이후 previousPageLabel에 메시지소스 값이 반영된다")
+	void testInitMessageLabelsPreviousLabel() {
+		String label = (String) ReflectionTestUtils.getField(renderer, "previousPageLabel");
+		assertThat(label).contains("이전");
+	}
+
+	@Test
+	@DisplayName("initMessageLabels 이후 nextPageLabel에 메시지소스 값이 반영된다")
+	void testInitMessageLabelsNextLabel() {
+		String label = (String) ReflectionTestUtils.getField(renderer, "nextPageLabel");
+		assertThat(label).contains("다음");
+	}
+
+	@Test
+	@DisplayName("initMessageLabels 이후 previousPageDisabledLabel에 disabled 클래스가 포함된다")
+	void testInitMessageLabelsPreviousDisabledLabel() {
+		String label = (String) ReflectionTestUtils.getField(renderer, "previousPageDisabledLabel");
+		assertThat(label).contains("disabled").contains("이전");
+	}
+
+	@Test
+	@DisplayName("initMessageLabels 이후 nextPageDisabledLabel에 disabled 클래스가 포함된다")
+	void testInitMessageLabelsNextDisabledLabel() {
+		String label = (String) ReflectionTestUtils.getField(renderer, "nextPageDisabledLabel");
+		assertThat(label).contains("disabled").contains("다음");
+	}
+
+	@Test
+	@DisplayName("renderPagination은 null이 아닌 HTML 문자열을 반환한다")
+	void testRenderPaginationReturnsHtml() {
+		PaginationInfo paginationInfo = new PaginationInfo();
+		paginationInfo.setCurrentPageNo(1);
+		paginationInfo.setRecordCountPerPage(10);
+		paginationInfo.setPageSize(5);
+		paginationInfo.setTotalRecordCount(50);
+
+		String result = renderer.renderPagination(paginationInfo, "fn_egov_link_page");
+		assertThat(result).isNotNull().isNotEmpty();
+	}
+
+	@Test
+	@DisplayName("renderPagination 결과에 페이지 링크 HTML이 포함된다")
+	void testRenderPaginationContainsPageLink() {
+		PaginationInfo paginationInfo = new PaginationInfo();
+		paginationInfo.setCurrentPageNo(3);
+		paginationInfo.setRecordCountPerPage(10);
+		paginationInfo.setPageSize(5);
+		paginationInfo.setTotalRecordCount(100);
+
+		String result = renderer.renderPagination(paginationInfo, "fn_egov_link_page");
+		assertThat(result).contains("fn_egov_link_page");
+	}
+
+}


### PR DESCRIPTION
## 변경 사유

`EgovKrdsPaginationRenderer`는 페이지 네비게이션 HTML을 생성하는 핵심 컴포넌트이나 기존에 단위 테스트가 없었습니다. `MessageSource` 의존성을 Mockito로 mock하여 Spring 컨텍스트 없이 동작을 검증합니다.

## 변경 내용

- `src/test/java/egovframework/example/pagination/EgovKrdsPaginationRendererTest.java` 신규 추가

## 테스트 항목 (10개)

- `initVariables()` 후 previousPageLabel / nextPageLabel / currentPageLabel / dotPageLabel 검증
- `initMessageLabels()` 후 메시지소스 반영(prev/next 레이블) 및 disabled 레이블 검증
- `renderPagination()` HTML 출력 null 여부 및 jsFunction 문자열 포함 여부 검증

## 영향 범위

테스트 코드만 추가. 운영 코드 변경 없음.

## 체크리스트

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 기존 동작에 영향 없음
- [x] 테스트 통과 확인 (`mvn test -Dtest=EgovKrdsPaginationRendererTest` → 10/10 passed)
