### PR TITLE
[test][boot-sample] SampleMapper update/delete/selectList/selectListTotCnt 단위 테스트 추가

### DIFF
--- a/src/test/java/egovframework/example/sample/service/impl/SampleMapperTestDeleteSampleTest.java
+++ b/src/test/java/egovframework/example/sample/service/impl/SampleMapperTestDeleteSampleTest.java
@@ -1,0 +1,63 @@
+package egovframework.example.sample.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.time.LocalDateTime;
+
+import org.egovframe.rte.fdl.idgnr.EgovIdGnrService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import egovframework.example.sample.service.SampleVO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * [게시판][SampleMapper.deleteSample] DAO 단위 테스트
+ *
+ * @author 이백행
+ * @since 2024-09-19
+ *
+ */
+@SpringBootTest
+@RequiredArgsConstructor
+@Slf4j
+class SampleMapperTestDeleteSampleTest {
+
+	@Autowired
+	private SampleMapper sampleMapper;
+
+	@Autowired
+	private EgovIdGnrService egovIdGnrService;
+
+	@Test
+	void test() throws Exception {
+		// given
+		final SampleVO sampleVO = new SampleVO();
+		sampleVO.setId(egovIdGnrService.getNextStringId());
+
+		final String now = LocalDateTime.now().toString();
+
+		sampleVO.setName("test 이백행 카테고리명 " + now);
+		sampleVO.setDescription("test 이백행 설명 " + now);
+		sampleVO.setUseYn("Y");
+		sampleVO.setRegUser("eGov");
+
+		sampleMapper.insertSample(sampleVO);
+
+		// when
+		sampleMapper.deleteSample(sampleVO);
+
+		// then
+		final SampleVO resultSampleVO = sampleMapper.selectSample(sampleVO);
+
+		if (log.isDebugEnabled()) {
+			log.debug("sampleVO={}", sampleVO);
+			log.debug("resultSampleVO={}", resultSampleVO);
+		}
+
+		assertNull(resultSampleVO, "글을 삭제한다. 삭제 후 조회 결과 없음");
+	}
+
+}

--- a/src/test/java/egovframework/example/sample/service/impl/SampleMapperTestSelectSampleListTest.java
+++ b/src/test/java/egovframework/example/sample/service/impl/SampleMapperTestSelectSampleListTest.java
@@ -1,0 +1,70 @@
+package egovframework.example.sample.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.egovframe.rte.fdl.idgnr.EgovIdGnrService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import egovframework.example.sample.service.SampleVO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * [게시판][SampleMapper.selectSampleList] DAO 단위 테스트
+ *
+ * @author 이백행
+ * @since 2024-09-19
+ *
+ */
+@SpringBootTest
+@RequiredArgsConstructor
+@Slf4j
+class SampleMapperTestSelectSampleListTest {
+
+	@Autowired
+	private SampleMapper sampleMapper;
+
+	@Autowired
+	private EgovIdGnrService egovIdGnrService;
+
+	@Test
+	void test() throws Exception {
+		// given
+		final SampleVO sampleVO = new SampleVO();
+		sampleVO.setId(egovIdGnrService.getNextStringId());
+
+		final String now = LocalDateTime.now().toString();
+
+		sampleVO.setName("test 이백행 카테고리명 " + now);
+		sampleVO.setDescription("test 이백행 설명 " + now);
+		sampleVO.setUseYn("Y");
+		sampleVO.setRegUser("eGov");
+
+		sampleMapper.insertSample(sampleVO);
+
+		// when
+		final SampleVO searchVO = new SampleVO();
+		searchVO.setRecordCountPerPage(10);
+		searchVO.setFirstIndex(0);
+		searchVO.setSearchCondition("1");
+		searchVO.setSearchKeyword(sampleVO.getName());
+
+		final List<?> resultList = sampleMapper.selectSampleList(searchVO);
+
+		if (log.isDebugEnabled()) {
+			log.debug("searchVO={}", searchVO);
+			log.debug("resultList={}", resultList);
+		}
+
+		// then
+		assertNotNull(resultList, "목록 조회 결과가 null이 아님");
+		assertFalse(resultList.isEmpty(), "목록 조회 결과가 비어 있지 않음");
+	}
+
+}

--- a/src/test/java/egovframework/example/sample/service/impl/SampleMapperTestSelectSampleListTotCntTest.java
+++ b/src/test/java/egovframework/example/sample/service/impl/SampleMapperTestSelectSampleListTotCntTest.java
@@ -1,0 +1,65 @@
+package egovframework.example.sample.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDateTime;
+
+import org.egovframe.rte.fdl.idgnr.EgovIdGnrService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import egovframework.example.sample.service.SampleVO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * [게시판][SampleMapper.selectSampleListTotCnt] DAO 단위 테스트
+ *
+ * @author 이백행
+ * @since 2024-09-19
+ *
+ */
+@SpringBootTest
+@RequiredArgsConstructor
+@Slf4j
+class SampleMapperTestSelectSampleListTotCntTest {
+
+	@Autowired
+	private SampleMapper sampleMapper;
+
+	@Autowired
+	private EgovIdGnrService egovIdGnrService;
+
+	@Test
+	void test() throws Exception {
+		// given
+		final SampleVO sampleVO = new SampleVO();
+		sampleVO.setId(egovIdGnrService.getNextStringId());
+
+		final String now = LocalDateTime.now().toString();
+
+		sampleVO.setName("test 이백행 카테고리명 " + now);
+		sampleVO.setDescription("test 이백행 설명 " + now);
+		sampleVO.setUseYn("Y");
+		sampleVO.setRegUser("eGov");
+
+		sampleMapper.insertSample(sampleVO);
+
+		// when
+		final SampleVO searchVO = new SampleVO();
+		searchVO.setSearchCondition("1");
+		searchVO.setSearchKeyword(sampleVO.getName());
+
+		final int totCnt = sampleMapper.selectSampleListTotCnt(searchVO);
+
+		if (log.isDebugEnabled()) {
+			log.debug("searchVO={}", searchVO);
+			log.debug("totCnt={}", totCnt);
+		}
+
+		// then
+		assertTrue(totCnt > 0, "전체 건수가 1 이상임");
+	}
+
+}

--- a/src/test/java/egovframework/example/sample/service/impl/SampleMapperTestUpdateSampleTest.java
+++ b/src/test/java/egovframework/example/sample/service/impl/SampleMapperTestUpdateSampleTest.java
@@ -1,0 +1,80 @@
+package egovframework.example.sample.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.LocalDateTime;
+
+import org.egovframe.rte.fdl.idgnr.EgovIdGnrService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import egovframework.example.sample.service.SampleVO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * [게시판][SampleMapper.updateSample] DAO 단위 테스트
+ *
+ * @author 이백행
+ * @since 2024-09-19
+ *
+ */
+@SpringBootTest
+@RequiredArgsConstructor
+@Slf4j
+class SampleMapperTestUpdateSampleTest {
+
+	@Autowired
+	private SampleMapper sampleMapper;
+
+	@Autowired
+	private EgovIdGnrService egovIdGnrService;
+
+	@Test
+	void test() throws Exception {
+		// given
+		final SampleVO sampleVO = new SampleVO();
+		sampleVO.setId(egovIdGnrService.getNextStringId());
+
+		final String now = LocalDateTime.now().toString();
+
+		sampleVO.setName("test 이백행 카테고리명 " + now);
+		sampleVO.setDescription("test 이백행 설명 " + now);
+		sampleVO.setUseYn("Y");
+		sampleVO.setRegUser("eGov");
+
+		sampleMapper.insertSample(sampleVO);
+
+		// when
+		final String updatedNow = LocalDateTime.now().toString();
+		sampleVO.setName("test 이백행 수정 카테고리명 " + updatedNow);
+		sampleVO.setDescription("test 이백행 수정 설명 " + updatedNow);
+		sampleVO.setUseYn("N");
+
+		sampleMapper.updateSample(sampleVO);
+
+		// then
+		final SampleVO resultSampleVO = sampleMapper.selectSample(sampleVO);
+
+		if (log.isDebugEnabled()) {
+			log.debug("sampleVO={}", sampleVO);
+			log.debug("resultSampleVO={}", resultSampleVO);
+
+			log.debug("getId={}, {}", sampleVO.getId(), resultSampleVO.getId());
+			log.debug("getName={}, {}", sampleVO.getName(), resultSampleVO.getName());
+			log.debug("getDescription={}, {}", sampleVO.getDescription(), resultSampleVO.getDescription());
+			log.debug("getUseYn={}, {}", sampleVO.getUseYn(), resultSampleVO.getUseYn());
+		}
+
+		asserts(sampleVO, resultSampleVO);
+	}
+
+	private void asserts(final SampleVO sampleVO, final SampleVO resultSampleVO) {
+		assertEquals(sampleVO.getId(), resultSampleVO.getId(), "글을 수정한다. getId");
+		assertEquals(sampleVO.getName(), resultSampleVO.getName(), "글을 수정한다. 카테고리명");
+		assertEquals(sampleVO.getDescription(), resultSampleVO.getDescription(), "글을 수정한다. 설명");
+		assertEquals(sampleVO.getUseYn(), resultSampleVO.getUseYn(), "글을 수정한다. 사용여부");
+	}
+
+}


### PR DESCRIPTION
## 변경 사유

`SampleMapperTestInsertSampleTest`가 insertSample만 검증하고 있어 updateSample, deleteSample, selectSampleList, selectSampleListTotCnt에 대한 DAO 레이어 테스트가 없었다. CRUD 전 범위에 대한 단위 테스트를 추가하여 MyBatis 매퍼 동작을 검증한다.

## 변경 내용

- `SampleMapperTestUpdateSampleTest`: 수정 후 name, description, useYn 변경 확인
- `SampleMapperTestDeleteSampleTest`: 삭제 후 selectSample 결과 null 확인
- `SampleMapperTestSelectSampleListTest`: 키워드 검색으로 목록 조회 결과 비어 있지 않음 확인
- `SampleMapperTestSelectSampleListTotCntTest`: 키워드 검색으로 전체 건수 1 이상 확인

## 영향 범위

테스트 코드만 추가. 운영 코드 변경 없음.

## 체크리스트

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 기존 동작 호환
- [x] 테스트 통과 확인 (4/4 PASS)
