### PR TITLE
[chore] k8s deployment·service 매니페스트 추가

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: egovframe-boot-sample
+  labels:
+    app: egovframe-boot-sample
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: egovframe-boot-sample
+  template:
+    metadata:
+      labels:
+        app: egovframe-boot-sample
+    spec:
+      containers:
+        - name: egovframe-boot-sample
+          image: egovframe-boot-sample:latest
+          ports:
+            - containerPort: 8080
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: default

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: egovframe-boot-sample
+spec:
+  selector:
+    app: egovframe-boot-sample
+  type: NodePort
+  ports:
+    - port: 8080
+      targetPort: 8080
+      nodePort: 30060


### PR DESCRIPTION
## 변경 사유
k8s 배포용 기본 매니페스트가 없어 로컬/클라우드 데모 환경 구성이 번거롭습니다.

## 변경 내용
- k8s/deployment.yaml + service.yaml (NodePort 30060, 포트 8080)

## 영향 범위
- k8s 디렉토리 신규, 기존 코드/빌드 영향 없음

## 체크리스트
- [x] 단일 주제만 다룸
