### PR TITLE
[test][main] SampleMapper 단건조회 및 EgovSampleServiceImpl insertSample Mock 단위 테스트 추가

### DIFF
--- a/src/test/java/egovframework/example/sample/service/impl/EgovSampleServiceImplTestInsertSampleMockTest.java
+++ b/src/test/java/egovframework/example/sample/service/impl/EgovSampleServiceImplTestInsertSampleMockTest.java
@@ -1,0 +1,83 @@
+package egovframework.example.sample.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.egovframe.rte.fdl.idgnr.EgovIdGnrService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import egovframework.example.sample.service.SampleVO;
+
+/**
+ * [게시판][EgovSampleServiceImpl.insertSample] ServiceImpl Mock 단위 테스트
+ *
+ * SampleMapper와 EgovIdGnrService를 Mock으로 교체하여
+ * 스프링 컨텍스트 없이 insertSample 로직을 검증한다.
+ *
+ * @author 표준프레임워크센터
+ * @since 2026-05-29
+ */
+@ExtendWith(MockitoExtension.class)
+class EgovSampleServiceImplTestInsertSampleMockTest {
+
+	@Mock
+	private SampleMapper sampleMapper;
+
+	@Mock
+	private EgovIdGnrService egovIdGnrService;
+
+	@InjectMocks
+	private EgovSampleServiceImpl sut;
+
+	private SampleVO sampleVO;
+
+	@BeforeEach
+	void setUp() {
+		sampleVO = new SampleVO();
+		sampleVO.setName("테스트 카테고리");
+		sampleVO.setDescription("테스트 설명");
+		sampleVO.setUseYn("Y");
+		sampleVO.setRegUser("eGov");
+	}
+
+	@Test
+	@DisplayName("글 등록 - ID 생성 서비스에서 ID를 발급받아 VO에 설정하고 매퍼를 호출한다")
+	void insertSample_idGeneratedAndMapperCalled() throws Exception {
+		// given
+		String generatedId = "SAMPLE-001";
+		when(egovIdGnrService.getNextStringId()).thenReturn(generatedId);
+		doNothing().when(sampleMapper).insertSample(any(SampleVO.class));
+
+		// when
+		sut.insertSample(sampleVO);
+
+		// then
+		assertEquals(generatedId, sampleVO.getId(), "글을 등록한다. 생성된 ID가 VO에 설정됨");
+		verify(egovIdGnrService).getNextStringId();
+		verify(sampleMapper).insertSample(sampleVO);
+	}
+
+	@Test
+	@DisplayName("글 등록 - 등록 전 VO의 ID는 null이다")
+	void insertSample_idIsNullBeforeInsert() throws Exception {
+		// given
+		when(egovIdGnrService.getNextStringId()).thenReturn("SAMPLE-002");
+		doNothing().when(sampleMapper).insertSample(any(SampleVO.class));
+
+		// when
+		sut.insertSample(sampleVO);
+
+		// then
+		assertEquals("SAMPLE-002", sampleVO.getId(), "글을 등록한다. ID 생성 서비스가 반환한 값이 설정됨");
+	}
+
+}

--- a/src/test/java/egovframework/example/sample/service/impl/SampleMapperTestSelectSampleTest.java
+++ b/src/test/java/egovframework/example/sample/service/impl/SampleMapperTestSelectSampleTest.java
@@ -1,0 +1,66 @@
+package egovframework.example.sample.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.time.LocalDateTime;
+
+import org.egovframe.rte.fdl.idgnr.EgovIdGnrService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import egovframework.example.sample.service.SampleVO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * [게시판][SampleMapper.selectSample] DAO 단위 테스트
+ *
+ * @author 표준프레임워크센터
+ * @since 2026-05-29
+ */
+@SpringBootTest
+@RequiredArgsConstructor
+@Slf4j
+class SampleMapperTestSelectSampleTest {
+
+	@Autowired
+	private SampleMapper sampleMapper;
+
+	@Autowired
+	private EgovIdGnrService egovIdGnrService;
+
+	@Test
+	void test() throws Exception {
+		// given
+		final SampleVO sampleVO = new SampleVO();
+		sampleVO.setId(egovIdGnrService.getNextStringId());
+
+		final String now = LocalDateTime.now().toString();
+
+		sampleVO.setName("test 단건조회 카테고리명 " + now);
+		sampleVO.setDescription("test 단건조회 설명 " + now);
+		sampleVO.setUseYn("Y");
+		sampleVO.setRegUser("eGov");
+
+		sampleMapper.insertSample(sampleVO);
+
+		// when
+		final SampleVO resultSampleVO = sampleMapper.selectSample(sampleVO);
+
+		if (log.isDebugEnabled()) {
+			log.debug("sampleVO={}", sampleVO);
+			log.debug("resultSampleVO={}", resultSampleVO);
+		}
+
+		// then
+		assertNotNull(resultSampleVO, "단건 조회 결과가 null이 아님");
+		assertEquals(sampleVO.getId(), resultSampleVO.getId(), "글을 조회한다. getId");
+		assertEquals(sampleVO.getName(), resultSampleVO.getName(), "글을 조회한다. 카테고리명");
+		assertEquals(sampleVO.getDescription(), resultSampleVO.getDescription(), "글을 조회한다. 설명");
+		assertEquals(sampleVO.getUseYn(), resultSampleVO.getUseYn(), "글을 조회한다. 사용여부");
+		assertEquals(sampleVO.getRegUser(), resultSampleVO.getRegUser(), "글을 조회한다. 등록자");
+	}
+
+}


### PR DESCRIPTION
기존 SampleMapper 테스트(insert/update/delete/selectList/selectListTotCnt)에서 누락된 selectSample 단건조회 통합 테스트와, EgovSampleServiceImpl에서 누락된 insertSample Mock 단위 테스트를 추가한다.

변경 내용:
- SampleMapperTestSelectSampleTest: insert 후 selectSample 호출하여 id/name/description/useYn/regUser 값 검증
- EgovSampleServiceImplTestInsertSampleMockTest: MockitoExtension 기반, EgovIdGnrService에서 발급된 ID가 VO에 설정되고 SampleMapper.insertSample()이 호출되는 흐름 검증 (Spring 컨텍스트 불필요)

- [ ] 단일 주제만 다룸 (테스트 추가 외 변경 없음)
- [ ] pom.xml 등 빌드 설정 변경 없음
- [ ] 기존 동작에 영향 없음
- [ ] 테스트 3건 BUILD SUCCESS 확인